### PR TITLE
extend Python support to 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [ 'jruby-9.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0' ]
-        python: [ '3.5', '3.6', '3.7', '3.8', '3.9' ]
+        ruby: [ 'jruby-9.2', '2.3', '3.0' ]
+        python: [ '3.3', '3.9' ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ If a Python process dies, a new one will be spawned on the next pygments.rb requ
 
 == System Requirements
 
-- Python >= 3.5
+- Python >= 3.3
 - Ruby >= 2.3
 
 == Installation


### PR DESCRIPTION
also, reduce CI matrix to only test oldest and newest supported Python/Ruby versions