### PR TITLE
resolves #187 add support for custom lexers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,8 +10,6 @@ Layout/LineLength:
   Max: 120
 Metrics/MethodLength:
   Enabled: false
-Security/MarshalLoad:
-  Enabled: false
 Style/StructInheritance:
   Enabled: false
 Style/Documentation:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,10 @@
 This document provides a high-level view of the changes to the {project-name} by release.
 For a detailed view of what has changed, refer to the {uri-repo}/commits/master[commit history] on GitHub.
 
+== Unreleased
+
+* Add support for custom lexers ({uri-repo}/pull/187[#187])
+
 == 2.1.0 (2021-02-14) - @slonopotamus
 
 * Update Pygments to 2.8.0

--- a/Rakefile
+++ b/Rakefile
@@ -29,18 +29,6 @@ task :bench do
 end
 
 # ==========================================================
-# Cache lexers
-# ==========================================================
-
-# Write all the lexers to a file for easy lookup
-task :lexers do
-  sh 'ruby cache_lexers.rb'
-end
-
-task(:test).enhance([:lexers])
-task(:build).enhance([:lexers])
-
-# ==========================================================
 # Vendor
 # ==========================================================
 

--- a/cache_lexers.rb
+++ b/cache_lexers.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require File.join(File.dirname(__FILE__), '/lib/pygments.rb')
-
-# Simple marshalling
-serialized_lexers = Marshal.dump(Pygments.lexers!)
-
-# Write to a file
-File.open('lexers', 'wb') { |file| file.write(serialized_lexers) }

--- a/lib/pygments.rb
+++ b/lib/pygments.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
-require File.join(File.dirname(__FILE__), 'pygments/popen')
 require 'forwardable'
 
-module Pygments
-  autoload :Lexer, 'pygments/lexer'
+require_relative 'pygments/lexer'
+require_relative 'pygments/popen'
 
+module Pygments
   class << self
     extend Forwardable
+
+    def lexers
+      LexerCache.instance.raw_lexers
+    end
 
     def engine
       Thread.current.thread_variable_get(:pygments_engine) ||
@@ -16,7 +20,6 @@ module Pygments
 
     def_delegators :engine,
                    :formatters,
-                   :lexers,
                    :lexers!,
                    :filters,
                    :styles,

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -103,25 +103,8 @@ module Pygments
       end
     end
 
-    # Get all lexers from a serialized array.
-    # This avoids needing to spawn mentos when it's not really needed
-    # (e.g., one-off jobs, loading the Rails env, etc).
-    #
-    # Should be preferred to #lexers!
-    #
-    # @return [Array<String>] an array of lexers
-    def lexers
-      lexer_file = File.join(__dir__, '..', '..', 'lexers')
-      begin
-        File.open(lexer_file, 'rb') do |f|
-          Marshal.load(f)
-        end
-      rescue Errno::ENOENT
-        raise MentosError, %(Error loading #{lexer_file}. Was it created and vendored?)
-      end
-    end
-
-    # Get back all available lexers from mentos itself
+    # Get all available lexers from mentos itself
+    # Do not use this method directly, instead use Pygments#lexers
     #
     # @return [Array<String>] an array of lexers
     def lexers!


### PR DESCRIPTION
pygments.rb no longer stores list of lexers in a file.
Instead, Pygments is queried for available lexers.

In order to avoid spawning Pygments process when pygments.rb is just loaded,
lexers are now stored in a lazily initialized cache.