### PR TITLE
Fix #256 by changing python Windows search heuristic

### DIFF
--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -196,8 +196,8 @@ module Pygments
     # Detect a suitable Python binary to use.
     def find_python_binary
       if Gem.win_platform?
-        return "python3" if which("python3")
-        return "python" if which("python")
+        return 'python3' if which('python3')
+        return 'python' if which('python')
         return %w[py -3] if which('py')
       end
 

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -196,9 +196,9 @@ module Pygments
     # Detect a suitable Python binary to use.
     def find_python_binary
       if Gem.win_platform?
-        return %w[py -3] if which('py')
-
         return [%w[python3 python].find { |py| !which(py).nil? }]
+        
+        return %w[py -3] if which('py')
       end
 
       # On non-Windows platforms, we simply rely on shebang

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -196,8 +196,8 @@ module Pygments
     # Detect a suitable Python binary to use.
     def find_python_binary
       if Gem.win_platform?
-        return [%w[python3 python].find { |py| !which(py).nil? }]
-        
+        return "python3" if which("python3")
+        return "python" if which("python")
         return %w[py -3] if which('py')
       end
 


### PR DESCRIPTION
Prefer `python3` and `python` over `py -3` on Windows. This will ensure that an active virtual environment is found, rather than an arbitrary system python.